### PR TITLE
Modify types of railways that constitute rail_access

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -9,8 +9,6 @@ policies:
           body:
               required: true
           dco: false
-          gpg:
-              required: true
           spellcheck:
               locale: US
           maximumOfOneCommit: false

--- a/src/main/java/de/geofabrik/railway_routing/ev/RailwayClass.java
+++ b/src/main/java/de/geofabrik/railway_routing/ev/RailwayClass.java
@@ -7,7 +7,7 @@ import com.graphhopper.util.Helper;
  * This enum defines the railway class of an edge. It maps the railway=* key of OSM to an enum. All edges that do not fit get OTHER as value.
  */
 public enum RailwayClass {
-    OTHER, RAIL, SUBWAY, TRAM, NARROW_GAUGE, LIGHT_RAIL, FUNICULAR;
+    OTHER, RAIL, SUBWAY, TRAM, NARROW_GAUGE, LIGHT_RAIL, FUNICULAR, CONSTRUCTION;
 
     public static final String KEY = "railway_class";
 

--- a/src/main/java/de/geofabrik/railway_routing/parsers/RailAccessParser.java
+++ b/src/main/java/de/geofabrik/railway_routing/parsers/RailAccessParser.java
@@ -1,5 +1,7 @@
 package de.geofabrik.railway_routing.parsers;
 
+import java.util.Set;
+
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.VehicleAccess;
@@ -13,6 +15,9 @@ import com.graphhopper.util.PMap;
 public class RailAccessParser extends AbstractAccessParser {
 
     public static final String DEFAULT_NAME = "rail";
+    private static final Set<String> ALLOWED_RAIL_TYPES = Set.of(
+        "rail", "light_rail", "tram", "subway", "construction", "proposed", "funicular", "monorail"
+    );
 
     public RailAccessParser(BooleanEncodedValue accessEnc) {
         super(accessEnc, TransportationMode.TRAIN);
@@ -29,7 +34,7 @@ public class RailAccessParser extends AbstractAccessParser {
         if (railway == null) {
             return WayAccess.CAN_SKIP;
         }
-        if (railway.equals("rail") || railway.equals("light_rail") || railway.equals("tram") || railway.equals("subway") || railway.equals("narrow_gauge")) {
+        if (ALLOWED_RAIL_TYPES.contains(railway)) {
             return WayAccess.WAY;
         }
         return WayAccess.CAN_SKIP;

--- a/src/test/java/de/geofabrik/railway_routing/parsers/OSMRailwayClassParserTest.java
+++ b/src/test/java/de/geofabrik/railway_routing/parsers/OSMRailwayClassParserTest.java
@@ -70,6 +70,12 @@ class OSMRailwayClassParserTest {
         way.setTag("railway", "rail;tram");
         parser.handleWayTags(edgeId, edgeIntAccess, way, relFlags);
         assertEquals(RailwayClass.OTHER, classEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        way = new ReaderWay(29L);
+        way.setTag("railway", "construction");
+        parser.handleWayTags(edgeId, edgeIntAccess, way, relFlags);
+        assertEquals(RailwayClass.CONSTRUCTION, classEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 
 }

--- a/src/test/java/de/geofabrik/railway_routing/parsers/RailAccessParserTest.java
+++ b/src/test/java/de/geofabrik/railway_routing/parsers/RailAccessParserTest.java
@@ -46,6 +46,15 @@ public class RailAccessParserTest {
     }
 
     @Test
+    public void testAcceptsConstruction() {
+        PMap properties = new PMap();
+        RailAccessParser e = createAccessParser(createEncodingManager(), properties);
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("railway", "construction");
+        assertEquals(e.getAccess(way), WayAccess.WAY);
+    }
+
+    @Test
     public void testRejectRoad() {
         PMap properties = new PMap();
         RailAccessParser e = createAccessParser(createEncodingManager(), properties);

--- a/src/test/java/de/geofabrik/railway_routing/parsers/RailAccessParserTest.java
+++ b/src/test/java/de/geofabrik/railway_routing/parsers/RailAccessParserTest.java
@@ -55,4 +55,13 @@ public class RailAccessParserTest {
         way.setTag("railway", "rail");
         assertEquals(WayAccess.WAY, e.getAccess(way));
     }
+
+    @Test
+    public void testRejectsNarrowGauge() {
+        PMap properties = new PMap();
+        RailAccessParser e = createAccessParser(createEncodingManager(), properties);
+        ReaderWay way = new ReaderWay(1);
+        way.setTag("railway", "narrow_gauge");
+        assertEquals(WayAccess.CAN_SKIP, e.getAccess(way));
+    }
 }


### PR DESCRIPTION


This PR modifies the RailAccessParser to include and exclude the various OSM Railway types that we need to consider for the Remix rail routing product. See https://paper.dropbox.com/doc/Rail-routing-types-and-appearances--CcoTAuntwCvKSa99WV5edFPyAg-K1oQPVSL3s8eXf6SLyyow for more information about what we want to include and exclude.

After this change merges, the value of rail_access in the various custom costing profiles will change to include everything in the Set.

This addresses https://ridewithvia.atlassian.net/browse/REM-8628

A follow up PR will be needed in the monorepo to bust the cache on the curl request made to this repo in the dockerfile
