### PR TITLE
Dev env and Github actions

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,27 @@
+policies:
+    - type: commit
+      spec:
+          header:
+              length: 89
+              imperative: true
+              case: lower
+              invalidLastCharacters: .
+          body:
+              required: true
+          dco: false
+          gpg:
+              required: true
+          spellcheck:
+              locale: US
+          maximumOfOneCommit: false
+          conventional:
+              scopes:
+                  - master
+                  - deps
+              types:
+                  - feat
+                  - fix
+                  - chore
+                  - deps
+                  - docs
+                  - ci

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
+
+use devenv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: "Test"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v26
+    - uses: cachix/cachix-action@v14
+      with:
+        name: devenv
+    - name: Install devenv.sh
+      run: nix profile install nixpkgs#devenv
+
+    - name: Build the devenv shell and run any pre-commit hooks
+      run: devenv test
+
+    - name: OpenRailRouting tests
+      run: devenv shell mvn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # data
 graph-cache/
+data/
 
 # web frontend
 **/node_modules
@@ -154,3 +155,18 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 
 # End of https://www.gitignore.io/api/java,macos,maven,intellij
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml
+
+# jdtls
+.classpath
+.factorypath
+.project
+.settings/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Missing features:
 
 This project includes a web frontend which is a fork of the original GraphHopper web frontend.
 
+## Development environment
+
+We're using nix with [direnv](https://direnv.net/) and [devenv](https://devenv.sh/) to manage our development environment.
+
 ## Building
 
 This project uses Maven (for the Java code) and NodeJS for the web frontend for building.

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1731169617,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "983153344922e5fb8545aae7e5e70127da981a71",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1730963269,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "83fb6c028368e465cd19bb127b86f971a5e41ebc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1730814269,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,17 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  languages.java.enable = true;
+  languages.java.maven.enable = true;
+  languages.javascript.enable = true;
+
+  cachix.enable = false;
+
+  packages = with pkgs; [
+    osmctools
+  ];
+
+  pre-commit.hooks = {
+    conform.enable = true;
+  };
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend


### PR DESCRIPTION
Since we're planning on modifying more than a few small things in this fork, we should:

- Enable local and CI environments using nix 
- Plug the tests into a Github action

### QA steps

Since you already have nix and direnv installed, all you need to install now is devenv as a standalone tool:


```shell
nix profile install nixpkgs#devenv
```

After that all you need to do is run `direnv allow` in the path for this project.