### PR TITLE
fix: sync `RailwayClass` enum with `RailAccessParser` Set

### DIFF
--- a/src/main/java/de/geofabrik/railway_routing/ev/RailwayClass.java
+++ b/src/main/java/de/geofabrik/railway_routing/ev/RailwayClass.java
@@ -7,7 +7,7 @@ import com.graphhopper.util.Helper;
  * This enum defines the railway class of an edge. It maps the railway=* key of OSM to an enum. All edges that do not fit get OTHER as value.
  */
 public enum RailwayClass {
-    OTHER, RAIL, SUBWAY, TRAM, NARROW_GAUGE, LIGHT_RAIL, FUNICULAR, CONSTRUCTION;
+    OTHER, RAIL, SUBWAY, TRAM, LIGHT_RAIL, FUNICULAR, CONSTRUCTION, MONORAIL, PROPOSED;
 
     public static final String KEY = "railway_class";
 

--- a/src/test/java/de/geofabrik/railway_routing/parsers/OSMRailwayClassParserTest.java
+++ b/src/test/java/de/geofabrik/railway_routing/parsers/OSMRailwayClassParserTest.java
@@ -57,7 +57,7 @@ class OSMRailwayClassParserTest {
         way = new ReaderWay(29L);
         way.setTag("railway", "narrow_gauge");
         parser.handleWayTags(edgeId, edgeIntAccess, way, relFlags);
-        assertEquals(RailwayClass.NARROW_GAUGE, classEnc.getEnum(false, edgeId, edgeIntAccess));
+        assertEquals(RailwayClass.OTHER, classEnc.getEnum(false, edgeId, edgeIntAccess));
 
         edgeIntAccess = new ArrayEdgeIntAccess(1);
         way = new ReaderWay(29L);
@@ -76,6 +76,18 @@ class OSMRailwayClassParserTest {
         way.setTag("railway", "construction");
         parser.handleWayTags(edgeId, edgeIntAccess, way, relFlags);
         assertEquals(RailwayClass.CONSTRUCTION, classEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        way = new ReaderWay(29L);
+        way.setTag("railway", "proposed");
+        parser.handleWayTags(edgeId, edgeIntAccess, way, relFlags);
+        assertEquals(RailwayClass.PROPOSED, classEnc.getEnum(false, edgeId, edgeIntAccess));
+
+        edgeIntAccess = new ArrayEdgeIntAccess(1);
+        way = new ReaderWay(29L);
+        way.setTag("railway", "monorail");
+        parser.handleWayTags(edgeId, edgeIntAccess, way, relFlags);
+        assertEquals(RailwayClass.MONORAIL, classEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 
 }


### PR DESCRIPTION
These two data structures need to stay in sync so that the rail routing service operates as expected.

The values in `RailwayClass` are used for styling the ways The values in `RailAccessParser` are used for routing over those ways.

Summary of changes:
- `NARROW_GAUGE` - removed
- `MONORAIL` - added
- `PROPOSED` - added