### PR TITLE
feat: add `Dockerfile` to project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+target
+*.log
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM maven:3.9.5-eclipse-temurin-21
+
+# Install additional dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    tar \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set version of Graphhopper
+ARG GH_VERSION=9.1-osm-reader-callbacks
+
+# Download Graphhopper source code
+RUN curl -L https://github.com/geofabrik/graphhopper/archive/refs/tags/${GH_VERSION}.tar.gz -o graphhopper.tar.gz
+RUN mkdir -p /openrailrouting/graphhopper && tar -xzf graphhopper.tar.gz -C /openrailrouting/graphhopper --strip-components=1
+
+# Remove tarball
+RUN rm graphhopper.tar.gz
+
+# Copy OpenRailRouting source code into the container
+COPY . /openrailrouting
+
+# Set working directory to OpenRailRouting
+WORKDIR /openrailrouting
+
+# Clear Maven repository to ensure a fresh build
+RUN rm -rf ~/.m2/repository/*
+
+# Build OpenRailRouting and Graphhopper using Maven
+RUN mvn clean install -DskipTests
+
+# Expose necessary ports and run the application
+EXPOSE 8989
+
+CMD java -Xmx2G -Xms512m \
+    -Ddw.graphhopper.graph.location=/openrailrouting/osm/data-gh \
+    -Ddw.graphhopper.datareader.file=${OSM_PATH} \
+    -jar target/railway_routing-1.0.0.jar server ./config.yml


### PR DESCRIPTION
We want to add a `Dockerfile` to our fork of OpenRailRouting so that we can publish the built docker image to our private docker registry in order to reference it in our future tile generation pipeline for building tiles

Part of https://ridewithvia.atlassian.net/browse/REM-8675

### QA Steps
1. Checkout this branch
2. run `docker build -t open-rail-routing:latest .`
3. Navigate to `$REMIX_HOME/rail-routing/Dockerfile`
4. Replace contents of that Dockerfile with `FROM open-rail-routing:latest`
5. Run `./bin/develop` in the `$REMIX_HOME/rail-routing` dir.