### PR TITLE
fix: enable all rail ways to be routable

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -147,7 +147,8 @@ graphhopper:
   # the most simple case you can imagine an island without a bridge or ferry connection. The following parameter
   # allows setting a minimum size (number of edges) for such detached components. This can be used to reduce the number
   # of cases where a connection between locations might not be found.
-  prepare.min_network_size: 200
+  prepare.min_network_size: 0
+  prepare.min_one_way_network_size: 0
   prepare.subnetworks.threads: 1
 
   #### Routing ####


### PR DESCRIPTION
The default configuration throws out ways of a certain size that do not connect to the overall network graph. For our usecase at remix, we want to override that so that construction and proposed ways are routable for planning purposes

https://ridewithvia.atlassian.net/browse/REM-8770
